### PR TITLE
added check for assistant prepending to toolUIParts (closes #109)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -295,7 +295,10 @@ export default function Chat() {
                             );
                           }
 
-                          if (isToolUIPart(part) && m.id.startsWith("assistant")) {
+                          if (
+                            isToolUIPart(part) &&
+                            m.id.startsWith("assistant")
+                          ) {
                             const toolCallId = part.toolCallId;
                             const toolName = part.type.replace("tool-", "");
                             const needsConfirmation =


### PR DESCRIPTION
The message id of the duplicate tool UI part does not include the "assistant" prepending until the result is complete. Adding a quick check to the front end will skip the duplicated render.

Fixes #109 