### PR TITLE
Tell vite not to duplicate agents dependency

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src")
-    }
+    },
+    "dedupe": ["agents"],
   }
 });


### PR DESCRIPTION
This fixes an issue where getCurrentAgent doesn't work if vite decides to bundle agents multiple times https://github.com/cloudflare/agents/issues/570