### PR TITLE
check role for assistant not id

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -297,7 +297,7 @@ export default function Chat() {
 
                           if (
                             isToolUIPart(part) &&
-                            m.id.startsWith("assistant")
+                            m.role === "assistant"
                           ) {
                             const toolCallId = part.toolCallId;
                             const toolName = part.type.replace("tool-", "");


### PR DESCRIPTION
I also bumped into #129 

Seems like the `ToolInvocationCard` component was failing to surface due to a check that expected the response `id` to begin with the word assistant when this in fact is not the case.

This is a sample from the debug option in the UI (using using `gpt-4o-2024-11-20` )
```
{
  "id": "EeGnDXSxwwwNgdZI",
  "role": "assistant",
  "parts": [
    {
      "type": "step-start"
    },
    {
      "type": "tool-getWeatherInformation",
      "toolCallId": "call_0EJFi7aCpOWTfmQ6TCYn6gmt",
      "state": "input-available",
      "input": {
        "city": "Rio de Janeiro"
      },
      "callProviderMetadata": {
        "openai": {
          "itemId": "fc_09bdb8b7708398060068fca420c6f48190b88a55372be0f664"
        }
      }
    }
  ]
}
```