### PR TITLE
fix: render tool confirmation cards for assistant messages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -297,7 +297,7 @@ export default function Chat() {
 
                           if (
                             isToolUIPart(part) &&
-                            m.id.startsWith("assistant")
+                            m.role === "assistant"
                           ) {
                             const toolCallId = part.toolCallId;
                             const toolName = part.type.replace("tool-", "");
@@ -305,9 +305,6 @@ export default function Chat() {
                               toolsRequiringConfirmation.includes(
                                 toolName as keyof typeof tools
                               );
-
-                            // Skip rendering the card in debug mode
-                            if (showDebug) return null;
 
                             return (
                               <ToolInvocationCard


### PR DESCRIPTION
This PR fixes a bug where tool confirmation cards were not being rendered, making it impossible to approve or reject tool calls despite seeing the prompt "Please respond to the tool confirmation above..."

The bug occurred because message IDs are random strings (e.g., `8DjGnscSsFtj5gxy`), not prefixed with "assistant". The correct way to identify assistant messages is by checking the `role` property.

## Testing locally

```bash
gh repo clone cloudflare/agents-starter
cd agents-starter
gh pr checkout 132
npm install
npm start
```

Then ask a question that triggers a tool call requiring confirmation, such as "What's the weather like in Berkeley?"

You should now see the tool confirmation card with Approve/Reject buttons.

## Screenshots

| Before | After |
|:------:|:-----:|
| <img width="1736" height="2112" alt="before" src="https://github.com/user-attachments/assets/aff355c9-1204-4f7d-ad48-43eef6d866d9" /> |  <img width="1736" height="2112" alt="after" src="https://github.com/user-attachments/assets/61620738-f332-4fdf-8afb-5b2d3e6cd3bf" /> |

cc @threepointone 👋🏼 