### PR TITLE
Ensure MCP's jsonSchema is loaded before getAITools()

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,9 @@ export class Chat extends AIChatAgent<Env> {
     //   "https://path-to-mcp-server/sse"
     // );
 
+    // Ensure MCP's jsonSchema is loaded before getAITools() (avoids "jsonSchema not initialized" on first request)
+    await this.mcp.ensureJsonSchema();
+
     // Collect all tools, including MCP tools
     const allTools = {
       ...tools,


### PR DESCRIPTION
Frequently when attempting a tool call MCP's json schema is not loaded before getAITools() is called and it errors and does not make the tool call. This fixes it.

Error on server: Error: jsonSchema not initialized.
    at MCPClientManager.getAITools
    ...