### PR TITLE
Make example prompts clickable in empty state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -332,6 +332,7 @@ function Chat() {
                       key={prompt}
                       variant="outline"
                       size="sm"
+                      disabled={isStreaming}
                       onClick={() => {
                         sendMessage({
                           role: "user",


### PR DESCRIPTION
## Summary

- Replaces the static description text with clickable prompt buttons
- Clicking a button sends that prompt as a message immediately
- Uses Kumo's `Empty` component `contents` prop for the interactive elements

This improves the onboarding UX by letting users start a conversation with one click instead of having to copy/type the example prompts.

<img width="834" height="446" alt="Screenshot 2026-02-17 at 9 38 12 AM" src="https://github.com/user-attachments/assets/ba6548f7-931d-404d-a7ba-d9f43d8a1a4a" />

